### PR TITLE
feat(logs): Add optional extra logs to getDevices method

### DIFF
--- a/src/include/QtUsb/qusb.h
+++ b/src/include/QtUsb/qusb.h
@@ -104,6 +104,7 @@ protected:
 
 private:
     QUsbPrivate *const d_dummy;
+    static IdList getDevices(bool extraLogs = true);
     Q_DISABLE_COPY(QUsb)
 };
 


### PR DESCRIPTION
Extended logs in device() method.
The logs are optional. They are not printed by default when the method called on timer triggered.
They could be printed if logLevel() set to QUsb::LogLevel::Debug (Info by default) 
